### PR TITLE
enable_dolby_vision_hdmi.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,18 @@ Follow these steps to enable Dolby Vision on your PC:
 6. Open AW EDID Editor.
 7. Open the exported EDID file (`dolbyvisionmonitor.bin`).
 8. Navigate to the Vendor-Specific Video section.
-9. Edit the hex string. For example, if you own an LG C1, change the hex string from `480376825e6d95` to `480377825e6d95`. If your string is different, use [VSVDB Calc](https://discourse.coreelec.org/uploads/short-url/uJlVOw1StIgxqJnJyKuGwlC57vQ.xlsm) to calculate the correct value.
+9. Edit the hex string.
+    1. Below are some known, pre-computed (`original` -> `updated`) values:
+        * `480376825e6d95` -> `480377825e6d95` (LG C1)
+        * `480a7e86607694` -> `480a7f86607694` (LG C2)
+        * `4d4e4a725a7776` -> `4d4e4b725a7776` (TCL C825)
+        * `48039e5898aa5c` -> `48039f5898aa5c` (Sony A95L)
+        * `4403609248458f` -> `4403619248458f` (unknown model of Sony Bravia)
+    1. If your hex string is not listed above, then compute it via:
+        ```shell
+        python.exe enable_dolby_vision_hdmi.py __HEX_STRING__
+        ```
+    1. (If you want to dive deeper into the hex string config, consult [dolby_vsvdb_calc.xlsm](./dolby_vsvdb_calc.xlsm) from [here](https://discourse.coreelec.org/t/edid-override-injecting-a-dolby-vsvdb-block/51510?page=1)).
 10. Save the edited EDID as a new file (e.g., `fixeddolbyvisionmonitor.bin`).
 11. Open CRU again.
 12. Import the edited EDID file (`fixeddolbyvisionmonitor.bin`).

--- a/enable_dolby_vision_hdmi.py
+++ b/enable_dolby_vision_hdmi.py
@@ -6,7 +6,7 @@ def hex_to_int(hex: str):
 
 
 def int_to_hex(num: int):
-  return f'{num:x}'
+  return '%x' % num
 
 
 def enable_dolby_vision_hdmi(hex: str):

--- a/enable_dolby_vision_hdmi.py
+++ b/enable_dolby_vision_hdmi.py
@@ -1,0 +1,59 @@
+import sys
+
+
+def hex_to_int(hex: str):
+  return int(hex, 16)
+
+
+def int_to_hex(num: int):
+  return f'{num:x}'
+
+
+def enable_dolby_vision_hdmi(hex: str):
+  assert len(hex) == 14
+  hex_chunks_index = 2  # the index containing the dolby vision values
+
+  # split into chunks of 2 characters
+  hex_chunks = [hex[i : i + 2] for i in range(0, len(hex), 2)]
+
+  # set the last bit to enable 'LLDV-HDMI'
+  dolby_bits = hex_to_int(hex_chunks[hex_chunks_index])
+  dolby_bits |= 1
+
+  hex_chunks[hex_chunks_index] = int_to_hex(dolby_bits)
+  return ''.join(hex_chunks)
+
+
+def run_tests():
+  samples = (
+    ('480376825e6d95', '480377825e6d95'),  # https://github.com/balu100/dolby-vision-for-windows/blob/e393cbb47571e9053db4273e1cd62bb6ce162a21/README.md?plain=1#L23
+    ('4403609248458f', '4403619248458f'),  # https://github.com/balu100/dolby-vision-for-windows/issues/1#issuecomment-2188170968
+    ('4d4e4a725a7776', '4d4e4b725a7776'),  # https://github.com/balu100/dolby-vision-for-windows/issues/2#issue-2506429409
+    ('480a7e86607694', '480a7f86607694'),  # https://github.com/balu100/dolby-vision-for-windows/issues/2#issuecomment-2330407252
+    ('48039e5898aa5c', '48039f5898aa5c'),  # https://github.com/balu100/dolby-vision-for-windows/issues/2#issuecomment-2330708632
+  )
+  for hex_input, expected_hex_output in samples:
+    hex_output = enable_dolby_vision_hdmi(hex_input)
+    assert hex_output == expected_hex_output
+
+
+def main():
+  try:
+    video_hex = sys.argv[1]
+  except IndexError:
+    video_hex = None
+  else:
+    video_hex = video_hex.strip()
+
+  if not video_hex:
+    raise ValueError('No value provided for argument `video_hex`')
+
+  new_video_hex = enable_dolby_vision_hdmi(video_hex)
+  if new_video_hex == video_hex:
+    print("Warning: `video_hex` of '%s' is already enabled with LLDV-HDMI" % video_hex)
+  else:
+    print("Update `video_hex` from '%s' to '%s' to enable LLDV-HDMI" % (video_hex, new_video_hex))
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This PR adds a python script for computing an updated video hex string with enabled LLDV-HDMI.

Example:

```shell
python.exe enable_dolby_vision_hdmi.py 480376825e6d95
```

Output:

```log
Update `video_hex` from '480376825e6d95' to '480377825e6d95' to enable LLDV-HDMI
```

---

Testing:

I tested the script by using the [computed hex string](https://github.com/balu100/dolby-vision-for-windows/blob/b67834abe9a315bc2c63eefe506b1888fc58e4f6/README.md?plain=1#L28) for Sony A95L and confirmed that Windows Media Player is now able to play `Dolby Vision Mystery Box (Profile 5)` from [here](https://kodi.wiki/view/Samples#4K_(UltraHD)_Formats).

Because of the script's simplicity, it should work across any/all python versions.